### PR TITLE
Update debug_cmd.sh

### DIFF
--- a/readonlysd/debug_cmd.sh
+++ b/readonlysd/debug_cmd.sh
@@ -20,6 +20,10 @@ mkdir -p /home/busybox
 mount --bind /media/hack/busybox /bin/busybox
 /bin/busybox --install -s /home/busybox
 
+#symlink to dropbear's ssh client and the scp
+ln -s /media/hack/dropbearmulti /bin/ssh
+ln -s /media/hack/dropbearmulti /bin/scp
+
 # set new env
 mount --bind /media/hack/profile /etc/profile
 


### PR DESCRIPTION
Added symlinks to use dropbear as a ssh client and scp. As said by the binary itself: Make a symlink pointing at this binary with one of the following names or run 'dropbearmulti <command>'.
'dropbear' - the Dropbear server
'dbclient' or 'ssh' - the Dropbear client
'scp' - secure copy