### PR TITLE
set up wifi for goke gk7102 soc without an app

### DIFF
--- a/readonlysd/debug_cmd.sh
+++ b/readonlysd/debug_cmd.sh
@@ -14,6 +14,11 @@ fi
 # confirm hack type
 touch /home/HACKSD
 
+# Setup wifi without app
+echo "[cls_server]" > cls.conf
+echo "ssid = NETWORK_SSID" >> cls.conf
+echo "passwd = NETWORK_PASS" >> cls.conf
+
 mkdir -p /home/busybox
 
 # install updated version of busybox


### PR DESCRIPTION
This should automatically log in to the network without having to use the app, in the case that one of these cloud cameras goes down.

<img width="1443" height="782" alt="image" src="https://github.com/user-attachments/assets/82bdcf63-2826-45aa-91e4-b6db35637f5f" />
